### PR TITLE
[SYCL][Fusion] Test kernel fusion and optimization

### DIFF
--- a/SYCL/BFloat16/bfloat16_builtins.cpp
+++ b/SYCL/BFloat16/bfloat16_builtins.cpp
@@ -29,8 +29,6 @@ bool check(float a, float b) {
   return fabs(2 * (a - b) / (a + b)) > bf16_eps * 2;
 }
 
-bool check(bool a, bool b) { return (a == b); }
-
 #define TEST_BUILTIN_1_SCAL_IMPL(NAME)                                         \
   {                                                                            \
     buffer<float> a_buf(&a[0], N);                                             \
@@ -48,7 +46,7 @@ bool check(bool a, bool b) { return (a == b); }
   }                                                                            \
   assert(err == 0);
 
-#define TEST_BUILTIN_1_ARR_IMPL(NAME, SZ, RETTY)                               \
+#define TEST_BUILTIN_1_ARR_IMPL(NAME, SZ)                                      \
   {                                                                            \
     buffer<float, 2> a_buf{range<2>{N / SZ, SZ}};                              \
     buffer<int> err_buf(&err, 1);                                              \
@@ -61,7 +59,7 @@ bool check(bool a, bool b) { return (a == b); }
         for (int i = 0; i < SZ; i++) {                                         \
           arg[i] = A[index][i];                                                \
         }                                                                      \
-        marray<RETTY, SZ> res = NAME(arg);                                     \
+        marray<bfloat16, SZ> res = NAME(arg);                                  \
         for (int i = 0; i < SZ; i++) {                                         \
           if (check(res[i], NAME(A[index][i]))) {                              \
             ERR[0] = 1;                                                        \
@@ -72,13 +70,13 @@ bool check(bool a, bool b) { return (a == b); }
   }                                                                            \
   assert(err == 0);
 
-#define TEST_BUILTIN_1(NAME, RETTY)                                            \
+#define TEST_BUILTIN_1(NAME)                                                   \
   TEST_BUILTIN_1_SCAL_IMPL(NAME)                                               \
-  TEST_BUILTIN_1_ARR_IMPL(NAME, 1, RETTY)                                      \
-  TEST_BUILTIN_1_ARR_IMPL(NAME, 2, RETTY)                                      \
-  TEST_BUILTIN_1_ARR_IMPL(NAME, 3, RETTY)                                      \
-  TEST_BUILTIN_1_ARR_IMPL(NAME, 4, RETTY)                                      \
-  TEST_BUILTIN_1_ARR_IMPL(NAME, 5, RETTY)
+  TEST_BUILTIN_1_ARR_IMPL(NAME, 1)                                             \
+  TEST_BUILTIN_1_ARR_IMPL(NAME, 2)                                             \
+  TEST_BUILTIN_1_ARR_IMPL(NAME, 3)                                             \
+  TEST_BUILTIN_1_ARR_IMPL(NAME, 4)                                             \
+  TEST_BUILTIN_1_ARR_IMPL(NAME, 5)
 
 #define TEST_BUILTIN_2_SCAL_IMPL(NAME)                                         \
   {                                                                            \
@@ -235,7 +233,7 @@ int main() {
       c[i] = (float)(3 * i);
     }
 
-    TEST_BUILTIN_1(fabs, bfloat16);
+    TEST_BUILTIN_1(fabs);
     TEST_BUILTIN_2(fmin);
     TEST_BUILTIN_2(fmax);
     TEST_BUILTIN_3(fma);
@@ -243,10 +241,6 @@ int main() {
     float check_nan = 0;
     TEST_BUILTIN_2_NAN(fmin);
     TEST_BUILTIN_2_NAN(fmax);
-
-    // Insert NAN value in a to test isnan
-    a[0] = a[N - 1] = NAN;
-    TEST_BUILTIN_1(isnan, bool);
   }
   return 0;
 }

--- a/SYCL/BFloat16/bfloat16_builtins.cpp
+++ b/SYCL/BFloat16/bfloat16_builtins.cpp
@@ -1,11 +1,11 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %if cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out
-
-// Currently the feature isn't supported on FPGA.
-
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
-// TODO: add test execution on FPGA
+// REQUIRES: cuda
 //
+// Currently this test fails to compile for backends other than cuda.
+// Other backends could use this test when bfloat16 math function support is
+// added.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend --cuda-gpu-arch=sm_80
+// RUN: %t.out
 #include <sycl/sycl.hpp>
 
 #include <cmath>

--- a/SYCL/BFloat16/bfloat16_builtins.cpp
+++ b/SYCL/BFloat16/bfloat16_builtins.cpp
@@ -222,26 +222,6 @@ bool check(bool a, bool b) { return (a == b); }
   assert(err == 0);                                                            \
   assert(std::isnan(check_nan));
 
-// The intention to introduce a proxy function for isnan is to bypass a compfail
-// on Win64 platform. If we simply pass 'isnan' to testing macro, compiler will
-// report 'ambiguous call' error. This is becayse MSVC header correct_math.h
-// includes an isnan definition too. In order to bypass this without modifying
-// current test infrastructure, we add proxy function for 'isnan' and uses full
-// name to avoid amibiguity.
-bool isnan_test_proxy(sycl::ext::oneapi::bfloat16 x) {
-  return sycl::ext::oneapi::experimental::isnan(x);
-}
-template <size_t N>
-sycl::marray<bool, N>
-isnan_test_proxy(sycl::marray<sycl::ext::oneapi::bfloat16, N> x) {
-  return sycl::ext::oneapi::experimental::isnan(x);
-}
-bool isnan_test_proxy(float x) { return sycl::isnan(x); }
-template <size_t N>
-sycl::marray<bool, N> isnan_test_proxy(sycl::marray<float, N> x) {
-  return sycl::isnan(x);
-}
-
 int main() {
   queue q;
 
@@ -266,7 +246,7 @@ int main() {
 
     // Insert NAN value in a to test isnan
     a[0] = a[N - 1] = NAN;
-    TEST_BUILTIN_1(isnan_test_proxy, bool);
+    TEST_BUILTIN_1(isnan, bool);
   }
   return 0;
 }

--- a/SYCL/BFloat16/bfloat16_builtins.cpp
+++ b/SYCL/BFloat16/bfloat16_builtins.cpp
@@ -1,11 +1,11 @@
-// REQUIRES: cuda
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %if cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out
+
+// Currently the feature isn't supported on FPGA.
+
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// TODO: add test execution on FPGA
 //
-// Currently this test fails to compile for backends other than cuda.
-// Other backends could use this test when bfloat16 math function support is
-// added.
-//
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend --cuda-gpu-arch=sm_80
-// RUN: %t.out
 #include <sycl/sycl.hpp>
 
 #include <cmath>

--- a/SYCL/Config/select_device.cpp
+++ b/SYCL/Config/select_device.cpp
@@ -1,6 +1,3 @@
-// Temporarily disabled due to flaky behavior
-// REQUIRES: TEMPORARY_DISABLED
-
 // RUN: %clangxx -fsycl %s -o %t.out
 //
 // RUN: env WRITE_DEVICE_INFO=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/lsc/atomic_smoke.cpp
+++ b/SYCL/ESIMD/lsc/atomic_smoke.cpp
@@ -604,10 +604,10 @@ int main(void) {
 #endif // USE_DWORD_ATOMICS
 #endif // CMPXCHG_TEST
 
-#ifndef USE_DWORD_ATOMICS
   // Check load/store operations
   passed &= test_int_types<8, ImplLoad>(q, cfg);
   passed &= test_int_types<8, ImplStore>(q, cfg);
+#ifndef USE_DWORD_ATOMICS
   passed &= test<float, 8, ImplStore>(q, cfg);
 #endif // USE_DWORD_ATOMICS
   // TODO: check double other vector lengths in LSC mode.

--- a/SYCL/KernelFusion/abort_fusion.cpp
+++ b/SYCL/KernelFusion/abort_fusion.cpp
@@ -1,0 +1,114 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
+// UNSUPPORTED: cuda || hip
+// REQUIRES: fusion
+
+// Test fusion being aborted: Different scenarios causing the JIT compiler
+// to abort fusion due to constraint violations for fusion. Also check that
+// warnings are printed when SYCL_RT_WARNING_LEVEL=1.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+constexpr size_t dataSize = 512;
+
+enum class Internalization { None, Local, Private };
+
+template <typename Kernel1Name, typename Kernel2Name, int Kernel1Dim>
+void performFusion(queue &q, int *in1, int *in2, int *in3, int *tmp, int *out,
+                   range<Kernel1Dim> k1Global, range<Kernel1Dim> k1Local) {
+  {
+    buffer<int> bIn1{in1, range{dataSize}};
+    buffer<int> bIn2{in2, range{dataSize}};
+    buffer<int> bIn3{in3, range{dataSize}};
+    buffer<int> bTmp{tmp, range{dataSize}};
+    buffer<int> bOut{out, range{dataSize}};
+
+    ext::codeplay::experimental::fusion_wrapper fw(q);
+    fw.start_fusion();
+
+    assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access(cgh);
+      auto accIn2 = bIn2.get_access(cgh);
+      auto accTmp = bTmp.get_access(cgh);
+      cgh.parallel_for<Kernel1Name>(
+          nd_range<Kernel1Dim>{k1Global, k1Local}, [=](item<Kernel1Dim> i) {
+            accTmp[i.get_linear_id()] =
+                accIn1[i.get_linear_id()] + accIn2[i.get_linear_id()];
+          });
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp = bTmp.get_access(cgh);
+      auto accIn3 = bIn3.get_access(cgh);
+      auto accOut = bOut.get_access(cgh);
+      cgh.parallel_for<Kernel2Name>(nd_range<1>{{dataSize}, {8}}, [=](id<1> i) {
+        accOut[i] = accTmp[i] * accIn3[i];
+      });
+    });
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+    assert(!fw.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+  }
+
+  // Check the results
+  size_t numErrors = 0;
+  for (size_t i = 0; i < k1Global.size(); ++i) {
+    if (out[i] != (20 * i * i)) {
+      ++numErrors;
+    }
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+  if (numErrors) {
+    std::cout << "COMPUTATION ERROR\n";
+  } else {
+    std::cout << "COMPUTATION OK\n";
+  }
+}
+
+int main() {
+  int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+
+  queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  // Scenario: Fusing two kernels with different dimensionality should lead to
+  // fusion being aborted.
+  performFusion<class Kernel1_1, class Kernel2_1>(
+      q, in1, in2, in3, tmp, out, range<2>{32, 16}, range<2>{1, 8});
+
+  // Scenario: Fusing two kernels with different global size should lead to
+  // fusion being aborted.
+  performFusion<class Kernel1_2, class Kernel2_2>(q, in1, in2, in3, tmp, out,
+                                                  range<1>{256}, range<1>{8});
+
+  // Scenario: Fusing two kernels with different local size should lead to
+  // fusion being aborted.
+  performFusion<class Kernel1_3, class Kernel2_3>(
+      q, in1, in2, in3, tmp, out, range<1>{dataSize}, range<1>{16});
+
+  return 0;
+}
+
+// CHECK: WARNING: Cannot fuse kernels with different dimensionality
+// CHECK-NEXT: COMPUTATION OK
+// CHECK-NEXT: WARNING: Cannot fuse kerneles with different global size
+// CHECK-NEXT: COMPUTATION OK
+// CHECK-NEXT: WARNING: Cannot fuse kernels with different local size
+// CHECK-NEXT: COMPUTATION OK

--- a/SYCL/KernelFusion/abort_internalization.cpp
+++ b/SYCL/KernelFusion/abort_internalization.cpp
@@ -1,0 +1,186 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_ENABLE_FUSION_CACHING=0 SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_ENABLE_FUSION_CACHING=0 SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
+// UNSUPPORTED: cuda || hip
+// REQUIRES: fusion
+
+// Test incomplete internalization: Different scenarios causing the JIT compiler
+// to abort internalization due to target or parameter mismatch. Also check that
+// warnings are printed when SYCL_RT_WARNING_LEVEL=1.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+constexpr size_t dataSize = 512;
+
+enum class Internalization { None, Local, Private };
+
+void performFusion(queue &q, int *in1, int *in2, int *in3, int *tmp, int *out,
+                   Internalization intKernel1, size_t localSizeKernel1,
+                   Internalization intKernel2, size_t localSizeKernel2,
+                   bool expectInternalization = false) {
+  {
+    buffer<int> bIn1{in1, range{dataSize}};
+    buffer<int> bIn2{in2, range{dataSize}};
+    buffer<int> bIn3{in3, range{dataSize}};
+    buffer<int> bTmp{tmp, range{dataSize}};
+    buffer<int> bOut{out, range{dataSize}};
+
+    ext::codeplay::experimental::fusion_wrapper fw{q};
+    fw.start_fusion();
+
+    assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access(cgh);
+      auto accIn2 = bIn2.get_access(cgh);
+      accessor<int> accTmp =
+          (intKernel1 == Internalization::Private)
+              ? bTmp.get_access(cgh, sycl::ext::codeplay::experimental::
+                                         property::promote_private{})
+              : (intKernel1 == Internalization::Local)
+                    ? bTmp.get_access(cgh, sycl::ext::codeplay::experimental::
+                                               property::promote_local{})
+                    : bTmp.get_access(cgh);
+      if (localSizeKernel1 > 0) {
+        cgh.parallel_for<class Kernel1>(
+            nd_range<1>{{dataSize}, {localSizeKernel1}},
+            [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+      } else {
+        cgh.parallel_for<class KernelOne>(
+            dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+      }
+    });
+
+    q.submit([&](handler &cgh) {
+      accessor<int> accTmp =
+          (intKernel2 == Internalization::Private)
+              ? bTmp.get_access(cgh, sycl::ext::codeplay::experimental::
+                                         property::promote_private{})
+              : (intKernel2 == Internalization::Local)
+                    ? bTmp.get_access(cgh, sycl::ext::codeplay::experimental::
+                                               property::promote_local{})
+                    : bTmp.get_access(cgh);
+      auto accIn3 = bIn3.get_access(cgh);
+      auto accOut = bOut.get_access(cgh);
+      if (localSizeKernel2 > 0) {
+        cgh.parallel_for<class Kernel2>(
+            nd_range<1>{{dataSize}, {localSizeKernel2}},
+            [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+      } else {
+        cgh.parallel_for<class KernelTwo>(
+            dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+      }
+    });
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+    assert(!fw.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+  }
+
+  // Check the results
+  size_t numErrors = 0;
+  size_t numInternalized = 0;
+  for (size_t i = 0; i < dataSize; ++i) {
+    if (out[i] != (20 * i * i)) {
+      ++numErrors;
+    }
+    if (tmp[i] == -1) {
+      ++numInternalized;
+    }
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+  if (numErrors) {
+    std::cout << "COMPUTATION ERROR\n";
+    return;
+  }
+  if (!expectInternalization && numInternalized) {
+    std::cout << "WRONG INTERNALIZATION\n";
+    return;
+  }
+  std::cout << "COMPUTATION OK\n";
+}
+
+int main() {
+  int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+
+  queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  // Scenario: One accessor without internalization, one with local
+  // internalization. Should fall back to no internalization and print a
+  // warning.
+  std::cout << "None, Local(0)\n";
+  performFusion(q, in1, in2, in3, tmp, out, Internalization::None, 0,
+                Internalization::Local, 0);
+  // Scenario: One accessor without internalization, one with private
+  // internalization. Should fall back to no internalization and print a
+  // warning.
+  std::cout << "None, Private\n";
+  performFusion(q, in1, in2, in3, tmp, out, Internalization::None, 0,
+                Internalization::Private, 0);
+
+  // Scenario: Both accessor with local promotion, but the second kernel does
+  // not specify a work-group size. No promotion should happen and a warning
+  // should be printed.
+  std::cout << "Local(8), Local(0)\n";
+  performFusion(q, in1, in2, in3, tmp, out, Internalization::Local, 8,
+                Internalization::Local, 0);
+
+  // Scenario: Both accessor with local promotion, but the first kernel does
+  // not specify a work-group size. No promotion should happen and a warning
+  // should be printed.
+  std::cout << "Local(0), Local(8)\n";
+  performFusion(q, in1, in2, in3, tmp, out, Internalization::Local, 0,
+                Internalization::Local, 8);
+
+  // Scenario: Both accessor with local promotion, but the kernels specify
+  // different work-group sizes. No promotion should happen and a warning should
+  // be printed.
+  std::cout << "Local(8), Local(16)\n";
+  performFusion(q, in1, in2, in3, tmp, out, Internalization::Local, 8,
+                Internalization::Local, 16);
+
+  // Scenario: One accessor with local internalization, one with private
+  // internalization. Should fall back to local internalization and print a
+  // warning.
+  std::cout << "Local(8), Private(8)\n";
+  performFusion(q, in1, in2, in3, tmp, out, Internalization::Local, 8,
+                Internalization::Private, 8, /* expectInternalization */ true);
+
+  return 0;
+}
+
+// CHECK: None, Local(0)
+// CHECK-NEXT: WARNING: Not performing specified local promotion, due to previous mismatch or because previous accessor specified no promotion
+// CHECK-NEXT: COMPUTATION OK
+// CHECK-NEXT: None, Private
+// CHECK-NEXT: WARNING: Not performing specified private promotion, due to previous mismatch or because previous accessor specified no promotion
+// CHECK-NEXT: COMPUTATION OK
+// CHECK-NEXT: Local(8), Local(0)
+// CHECK-NEXT: WARNING: Work-group size for local promotion not specified, not performing internalization
+// CHECK-NEXT: COMPUTATION OK
+// CHECK-NEXT: Local(0), Local(8)
+// CHECK-NEXT: WARNING: Work-group size for local promotion not specified, not performing internalization
+// CHECK-NEXT: WARNING: Not performing specified local promotion, due to previous mismatch or because previous accessor specified no promotion
+// CHECK-NEXT: WARNING: Cannot fuse kernels with different local size
+// CHECK-NEXT: COMPUTATION OK
+// CHECK-NEXT: Local(8), Local(16)
+// CHECK-NEXT: WARNING: Not performing specified local promotion due to work-group size mismatch
+// CHECK-NEXT: WARNING: Cannot fuse kernels with different local size
+// CHECK-NEXT: COMPUTATION OK
+// CHECK-NEXT: Local(8), Private(8)
+// CHECK-NEXT: WARNING: Performing local internalization instead, because previous accessor specified local promotion
+// CHECK-NEXT: COMPUTATION OK

--- a/SYCL/KernelFusion/barrier_local_internalization.cpp
+++ b/SYCL/KernelFusion/barrier_local_internalization.cpp
@@ -4,7 +4,8 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test cancel fusion
+// Test complete fusion with local internalization and a combination of kernels
+// that require a work-group barrier to be inserted by fusion.
 
 #include <sycl/sycl.hpp>
 
@@ -28,7 +29,10 @@ int main() {
     buffer<int> bIn1{in1, range{dataSize}};
     buffer<int> bIn2{in2, range{dataSize}};
     buffer<int> bIn3{in3, range{dataSize}};
-    buffer<int> bTmp{tmp, range{dataSize}};
+    buffer<int> bTmp{
+        tmp,
+        range{dataSize},
+        {sycl::ext::codeplay::experimental::property::promote_local{}}};
     buffer<int> bOut{out, range{dataSize}};
 
     ext::codeplay::experimental::fusion_wrapper fw{q};
@@ -41,7 +45,15 @@ int main() {
       auto accIn2 = bIn2.get_access(cgh);
       auto accTmp = bTmp.get_access(cgh);
       cgh.parallel_for<class KernelOne>(
-          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+          nd_range<1>{{dataSize}, {32}}, [=](nd_item<1> i) {
+            auto workgroupSize = i.get_local_range(0);
+            auto baseOffset = i.get_group_linear_id() * workgroupSize;
+            auto localIndex = i.get_local_linear_id();
+            auto localOffset = (workgroupSize - 1) - localIndex;
+            accTmp[baseOffset + localOffset] =
+                accIn1[baseOffset + localOffset] +
+                accIn2[baseOffset + localOffset];
+          });
     });
 
     q.submit([&](handler &cgh) {
@@ -49,10 +61,13 @@ int main() {
       auto accIn3 = bIn3.get_access(cgh);
       auto accOut = bOut.get_access(cgh);
       cgh.parallel_for<class KernelTwo>(
-          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+          nd_range<1>{{dataSize}, {32}}, [=](nd_item<1> i) {
+            auto index = i.get_global_linear_id();
+            accOut[index] = accTmp[index] * accIn3[index];
+          });
     });
 
-    fw.cancel_fusion();
+    fw.complete_fusion();
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");

--- a/SYCL/KernelFusion/complete_fusion.cpp
+++ b/SYCL/KernelFusion/complete_fusion.cpp
@@ -4,7 +4,7 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test cancel fusion
+// Test complete fusion without any internalization
 
 #include <sycl/sycl.hpp>
 
@@ -52,7 +52,7 @@ int main() {
           dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");

--- a/SYCL/KernelFusion/diamond_shape.cpp
+++ b/SYCL/KernelFusion/diamond_shape.cpp
@@ -1,0 +1,106 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// UNSUPPORTED: cuda || hip
+// REQUIRES: fusion
+
+// Test complete fusion with private internalization specified on the
+// accessors for a combination of four kernels, forming a diamond-like shape and
+// repeating one of the kernels.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+struct AddKernel {
+  accessor<int, 1> accIn1;
+  accessor<int, 1> accIn2;
+  accessor<int, 1> accOut;
+
+  void operator()(id<1> i) const { accOut[i] = accIn1[i] + accIn2[i]; }
+};
+
+int main() {
+  constexpr size_t dataSize = 512;
+  int in1[dataSize], in2[dataSize], in3[dataSize], tmp1[dataSize],
+      tmp2[dataSize], tmp3[dataSize], out[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp1[i] = -1;
+    tmp2[i] = -1;
+    tmp3[i] = -1;
+    out[i] = -1;
+  }
+
+  queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  {
+    buffer<int> bIn1{in1, range{dataSize}};
+    buffer<int> bIn2{in2, range{dataSize}};
+    buffer<int> bIn3{in3, range{dataSize}};
+    buffer<int> bTmp1{tmp1, range{dataSize}};
+    buffer<int> bTmp2{tmp2, range{dataSize}};
+    buffer<int> bTmp3{tmp3, range{dataSize}};
+    buffer<int> bOut{out, range{dataSize}};
+
+    ext::codeplay::experimental::fusion_wrapper fw{q};
+    fw.start_fusion();
+
+    assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access(cgh);
+      auto accIn2 = bIn2.get_access(cgh);
+      auto accTmp1 = bTmp1.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<AddKernel>(dataSize, AddKernel{accIn1, accIn2, accTmp1});
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp1 = bTmp1.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      auto accIn3 = bIn3.get_access(cgh);
+      auto accTmp2 = bTmp2.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<class KernelOne>(
+          dataSize, [=](id<1> i) { accTmp2[i] = accTmp1[i] * accIn3[i]; });
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp1 = bTmp1.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      auto accTmp3 = bTmp3.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<class KernelTwo>(
+          dataSize, [=](id<1> i) { accTmp3[i] = accTmp1[i] * 5; });
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp2 = bTmp2.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      auto accTmp3 = bTmp3.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      auto accOut = bOut.get_access(cgh);
+      cgh.parallel_for<AddKernel>(dataSize,
+                                  AddKernel{accTmp2, accTmp3, accOut});
+    });
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+    assert(!fw.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+  }
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[i] == (20 * i * i + i * 25) && "Computation error");
+    assert(tmp1[i] == -1 && "tmp1 not internalized");
+    assert(tmp2[i] == -1 && "tmp1 not internalized");
+    assert(tmp3[i] == -1 && "tmp1 not internalized");
+  }
+
+  return 0;
+}

--- a/SYCL/KernelFusion/event_wait_cancel.cpp
+++ b/SYCL/KernelFusion/event_wait_cancel.cpp
@@ -1,0 +1,77 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// UNSUPPORTED: cuda || hip
+
+// Test validity of events after cancel_fusion.
+
+#include "fusion_event_test_common.h"
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr size_t dataSize = 512;
+
+  queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  int *in1 = sycl::malloc_shared<int>(dataSize, q);
+  int *in2 = sycl::malloc_shared<int>(dataSize, q);
+  int *in3 = sycl::malloc_shared<int>(dataSize, q);
+  int *tmp = sycl::malloc_shared<int>(dataSize, q);
+  int *out = sycl::malloc_shared<int>(dataSize, q);
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+
+  ext::codeplay::experimental::fusion_wrapper fw{q};
+  fw.start_fusion();
+
+  assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+  auto kernel1 = q.submit([&](handler &cgh) {
+    cgh.parallel_for<class KernelOne>(
+        dataSize, [=](id<1> i) { tmp[i] = in1[i] + in2[i]; });
+  });
+
+  auto kernel2 = q.submit([&](handler &cgh) {
+    cgh.depends_on(kernel1);
+    cgh.parallel_for<class KernelTwo>(
+        dataSize, [=](id<1> i) { out[i] = tmp[i] * in3[i]; });
+  });
+
+  fw.cancel_fusion();
+
+  assert(!fw.is_in_fusion_mode() &&
+         "Queue should not be in fusion mode anymore");
+
+  kernel1.wait();
+  assert(isEventComplete(kernel1) && "Event should be complete");
+  // The event returned by submit while in fusion mode depends on both
+  // individual kernels to be executed.
+  assert(kernel1.get_wait_list().size() == 2);
+
+  kernel2.wait();
+  assert(isEventComplete(kernel2) && "Event should be complete");
+  // The event returned by submit while in fusion mode depends on both
+  // individual kernels to be executed.
+  assert(kernel2.get_wait_list().size() == 2);
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[i] == (20 * i * i) && "Computation error");
+  }
+
+  sycl::free(in1, q);
+  sycl::free(in2, q);
+  sycl::free(in3, q);
+  sycl::free(tmp, q);
+  sycl::free(out, q);
+
+  return 0;
+}

--- a/SYCL/KernelFusion/event_wait_complete.cpp
+++ b/SYCL/KernelFusion/event_wait_complete.cpp
@@ -4,7 +4,7 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test validity of events after cancel_fusion.
+// Test validity of events after complete_fusion.
 
 #include "fusion_event_test_common.h"
 
@@ -42,27 +42,34 @@ int main() {
   });
 
   auto kernel2 = q.submit([&](handler &cgh) {
-    cgh.depends_on(kernel1);
     cgh.parallel_for<class KernelTwo>(
         dataSize, [=](id<1> i) { out[i] = tmp[i] * in3[i]; });
   });
 
-  fw.cancel_fusion();
+  auto complete = fw.complete_fusion(
+      {ext::codeplay::experimental::property::no_barriers{}});
 
   assert(!fw.is_in_fusion_mode() &&
          "Queue should not be in fusion mode anymore");
 
+  complete.wait();
+  assert(isEventComplete(complete) && "Event should be complete");
+  // The execution of the fused kennel does not depend on any events.
+  assert(complete.get_wait_list().size() == 0);
+
   kernel1.wait();
   assert(isEventComplete(kernel1) && "Event should be complete");
-  // The event returned by submit while in fusion mode depends on both
-  // individual kernels to be executed.
-  assert(kernel1.get_wait_list().size() == 2);
+  // The event returned for submissions while in fusion mode depends on three
+  // events, for the two original kernels (which do not execute) the fused
+  // kernel to be executed.
+  assert(kernel1.get_wait_list().size() == 3);
 
   kernel2.wait();
   assert(isEventComplete(kernel2) && "Event should be complete");
-  // The event returned by submit while in fusion mode depends on both
-  // individual kernels to be executed.
-  assert(kernel2.get_wait_list().size() == 2);
+  // The event returned for submissions while in fusion mode depends on three
+  // events, for the two original kernels (which do not execute) the fused
+  // kernel to be executed.
+  assert(kernel2.get_wait_list().size() == 3);
 
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {

--- a/SYCL/KernelFusion/fusion_event_test_common.h
+++ b/SYCL/KernelFusion/fusion_event_test_common.h
@@ -1,0 +1,8 @@
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+static bool isEventComplete(sycl::event &ev) {
+  return ev.get_info<info::event::command_execution_status>() ==
+         info::event_command_status::complete;
+}

--- a/SYCL/KernelFusion/internal_explicit_dependency.cpp
+++ b/SYCL/KernelFusion/internal_explicit_dependency.cpp
@@ -4,7 +4,8 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test validity of events after cancel_fusion.
+// Test complete fusion where one kernel in the fusion list specifies an
+// explicit dependency (via events) on another kernel in the fusion list.
 
 #include "fusion_event_test_common.h"
 
@@ -47,22 +48,20 @@ int main() {
         dataSize, [=](id<1> i) { out[i] = tmp[i] * in3[i]; });
   });
 
-  fw.cancel_fusion();
+  auto complete = fw.complete_fusion(
+      {ext::codeplay::experimental::property::no_barriers{}});
 
   assert(!fw.is_in_fusion_mode() &&
          "Queue should not be in fusion mode anymore");
 
+  complete.wait();
+  assert(isEventComplete(complete) && "Event should be complete");
+
   kernel1.wait();
   assert(isEventComplete(kernel1) && "Event should be complete");
-  // The event returned by submit while in fusion mode depends on both
-  // individual kernels to be executed.
-  assert(kernel1.get_wait_list().size() == 2);
 
   kernel2.wait();
   assert(isEventComplete(kernel2) && "Event should be complete");
-  // The event returned by submit while in fusion mode depends on both
-  // individual kernels to be executed.
-  assert(kernel2.get_wait_list().size() == 2);
 
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {

--- a/SYCL/KernelFusion/internalize_array_wrapper.cpp
+++ b/SYCL/KernelFusion/internalize_array_wrapper.cpp
@@ -1,0 +1,139 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// UNSUPPORTED: cuda || hip
+// REQUIRES: fusion
+
+// Test internalization of a nested array type.
+
+#include <array>
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+template <size_t N, size_t M> struct array_wrapper {
+  static constexpr size_t rows{N};
+  static constexpr size_t columns{M};
+  static constexpr size_t vec_width{2};
+
+  using value_type = vec<int, vec_width>;
+  using reference_type = value_type &;
+  using const_reference_type = const value_type &;
+
+  std::array<std::array<value_type, columns>, rows> vs;
+
+  explicit array_wrapper(const_reference_type v) {
+    std::array<value_type, columns> el;
+    el.fill(v);
+    vs.fill(el);
+  }
+
+  array_wrapper() : array_wrapper{value_type{}} {}
+
+  constexpr std::array<value_type, columns> &operator[](size_t i) {
+    return vs[i];
+  }
+
+  constexpr const std::array<value_type, columns> &operator[](size_t i) const {
+    return vs[i];
+  }
+};
+
+int main() {
+  constexpr size_t dataSize = 2;
+  constexpr size_t rows = 2;
+  constexpr size_t columns = 2;
+
+  using array_type = array_wrapper<rows, columns>;
+
+  array_type in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize],
+      out[dataSize];
+
+  for (size_t id = 0; id < dataSize; ++id) {
+    for (size_t i = 0; i < rows; ++i) {
+      for (size_t j = 0; j < columns; ++j) {
+        in1[id][i][j].s0() = in1[id][i][j].s1() = id * 2;
+        in2[id][i][j].s0() = in2[id][i][j].s1() = id * 3;
+        in3[id][i][j].s0() = in3[id][i][j].s1() = id * 4;
+        tmp[id][i][j].s0() = tmp[id][i][j].s1() = -1;
+        out[id][i][j].s0() = out[id][i][j].s1() = -1;
+      }
+    }
+  }
+
+  queue q{default_selector_v,
+          {ext::codeplay::experimental::property::queue::enable_fusion{}}};
+
+  {
+    buffer<array_type> bIn1{in1, range{dataSize}};
+    buffer<array_type> bIn2{in2, range{dataSize}};
+    buffer<array_type> bIn3{in3, range{dataSize}};
+    buffer<array_type> bTmp{tmp, range{dataSize}};
+    buffer<array_type> bOut{out, range{dataSize}};
+
+    ext::codeplay::experimental::fusion_wrapper fw{q};
+    fw.start_fusion();
+
+    assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access(cgh);
+      auto accIn2 = bIn2.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<class KernelOne>(dataSize, [=](id<1> id) {
+        const auto &accIn1Wrapp = accIn1[id];
+        const auto &accIn2Wrapp = accIn2[id];
+        auto &accTmpWrapp = accTmp[id];
+        for (size_t i = 0; i < dataSize; ++i) {
+          const auto &in1 = accIn1Wrapp[i];
+          const auto &in2 = accIn2Wrapp[i];
+          auto &tmp = accTmpWrapp[i];
+          for (size_t j = 0; j < columns; ++j) {
+            tmp[j] = in1[j] + in2[j];
+          }
+        }
+      });
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      auto accIn3 = bIn3.get_access(cgh);
+      auto accOut = bOut.get_access(cgh);
+      cgh.parallel_for<class KernelTwo>(dataSize, [=](id<1> id) {
+        const auto &tmpWrapp = accTmp[id];
+        const auto &accIn3Wrapp = accIn3[id];
+        auto &accOutWrapp = accOut[id];
+        for (size_t i = 0; i < dataSize; ++i) {
+          const auto &tmp = tmpWrapp[i];
+          const auto &in3 = accIn3Wrapp[i];
+          auto &out = accOutWrapp[i];
+          for (size_t j = 0; j < columns; ++j) {
+            out[j] = tmp[j] * in3[j];
+          }
+        }
+      });
+    });
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+    assert(!fw.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+  }
+
+  // Check the results
+  constexpr array_type::value_type not_written{-1, -1};
+  for (size_t id = 0; id < dataSize; ++id) {
+    const array_type::value_type expected{20 * id * id, 20 * id * id};
+    for (size_t i = 0; i < rows; ++i) {
+      for (size_t j = 0; j < columns; ++j) {
+        assert(all(out[id][i][j] == expected) && "Computation error");
+        assert(all(tmp[id][i][j] == not_written) && "Not internalizing");
+      }
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/KernelFusion/internalize_deep.cpp
+++ b/SYCL/KernelFusion/internalize_deep.cpp
@@ -1,0 +1,106 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// UNSUPPORTED: cuda || hip
+// REQUIRES: fusion
+
+// Test complete fusion with internalization of a deep struct type.
+
+#include <type_traits>
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+struct deep_vec {
+  using value_type = vec<int, 4>;
+  struct level_0 {
+    struct level_1 {
+      struct level_2 {
+        deep_vec::value_type v;
+
+        constexpr level_2() = default;
+        constexpr explicit level_2(const deep_vec::value_type &v) : v{v} {}
+      } v;
+      constexpr level_1() = default;
+      constexpr explicit level_1(const deep_vec::value_type &v) : v{v} {}
+    } v;
+
+    constexpr level_0() = default;
+    constexpr explicit level_0(const deep_vec::value_type &v) : v{v} {}
+  } v;
+
+  constexpr deep_vec() = default;
+  constexpr explicit deep_vec(const value_type &v) : v{v} {}
+
+  constexpr value_type &operator*() { return v.v.v.v; }
+  constexpr value_type *operator->() { return &this->operator*(); }
+};
+
+deep_vec operator+(deep_vec lhs, deep_vec rhs) { return deep_vec{*lhs + *rhs}; }
+deep_vec operator*(deep_vec lhs, deep_vec rhs) { return deep_vec{*lhs * *rhs}; }
+
+int main() {
+  constexpr size_t dataSize = 512;
+
+  deep_vec in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize],
+      out[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i]->s0() = in1[i]->s1() = in1[i]->s2() = in1[i]->s3() = i * 2;
+    in2[i]->s0() = in2[i]->s1() = in2[i]->s2() = in2[i]->s3() = i * 3;
+    in3[i]->s0() = in3[i]->s1() = in3[i]->s2() = in3[i]->s3() = i * 4;
+    tmp[i]->s0() = tmp[i]->s1() = tmp[i]->s2() = tmp[i]->s3() = -1;
+    out[i]->s0() = out[i]->s1() = out[i]->s2() = out[i]->s3() = -1;
+  }
+
+  queue q{default_selector_v,
+          {ext::codeplay::experimental::property::queue::enable_fusion{}}};
+
+  {
+    buffer<deep_vec> bIn1{in1, range{dataSize}};
+    buffer<deep_vec> bIn2{in2, range{dataSize}};
+    buffer<deep_vec> bIn3{in3, range{dataSize}};
+    buffer<deep_vec> bTmp{tmp, range{dataSize}};
+    buffer<deep_vec> bOut{out, range{dataSize}};
+
+    ext::codeplay::experimental::fusion_wrapper fw{q};
+    fw.start_fusion();
+
+    assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access(cgh);
+      auto accIn2 = bIn2.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<class KernelOne>(
+          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      auto accIn3 = bIn3.get_access(cgh);
+      auto accOut = bOut.get_access(cgh);
+      cgh.parallel_for<class KernelTwo>(
+          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+    });
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+    assert(!fw.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+  }
+
+  // Check the results
+  constexpr deep_vec::value_type not_written{-1, -1, -1, -1};
+  for (size_t i = 0; i < dataSize; ++i) {
+    const deep_vec::value_type expected{20 * i * i, 20 * i * i, 20 * i * i,
+                                        20 * i * i};
+    assert(all(*out[i] == expected) && "Computation error");
+    assert(all(*tmp[i] == not_written) && "Not internalizing");
+  };
+
+  return 0;
+}

--- a/SYCL/KernelFusion/internalize_vec.cpp
+++ b/SYCL/KernelFusion/internalize_vec.cpp
@@ -1,0 +1,75 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// UNSUPPORTED: cuda || hip
+// REQUIRES: fusion
+
+// Test complete fusion with internalization of a struct type.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr size_t dataSize = 512;
+
+  vec<int, 4> in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize],
+      out[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i].s0() = in1[i].s1() = in1[i].s2() = in1[i].s3() = i * 2;
+    in2[i].s0() = in2[i].s1() = in2[i].s2() = in2[i].s3() = i * 3;
+    in3[i].s0() = in3[i].s1() = in3[i].s2() = in3[i].s3() = i * 4;
+    tmp[i].s0() = tmp[i].s1() = tmp[i].s2() = tmp[i].s3() = -1;
+    out[i].s0() = out[i].s1() = out[i].s2() = out[i].s3() = -1;
+  }
+
+  queue q{default_selector_v,
+          {ext::codeplay::experimental::property::queue::enable_fusion{}}};
+
+  {
+    buffer<vec<int, 4>> bIn1{in1, range{dataSize}};
+    buffer<vec<int, 4>> bIn2{in2, range{dataSize}};
+    buffer<vec<int, 4>> bIn3{in3, range{dataSize}};
+    buffer<vec<int, 4>> bTmp{tmp, range{dataSize}};
+    buffer<vec<int, 4>> bOut{out, range{dataSize}};
+
+    ext::codeplay::experimental::fusion_wrapper fw{q};
+    fw.start_fusion();
+
+    assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access(cgh);
+      auto accIn2 = bIn2.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<class KernelOne>(
+          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      auto accIn3 = bIn3.get_access(cgh);
+      auto accOut = bOut.get_access(cgh);
+      cgh.parallel_for<class KernelTwo>(
+          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+    });
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+    assert(!fw.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+  }
+
+  // Check the results
+  constexpr vec<int, 4> not_written{-1, -1, -1, -1};
+  for (size_t i = 0; i < dataSize; ++i) {
+    const vec<int, 4> expected{20 * i * i, 20 * i * i, 20 * i * i, 20 * i * i};
+    assert(all(out[i] == expected) && "Computation error");
+    assert(all(tmp[i] == not_written) && "Not internalizing");
+  };
+
+  return 0;
+}

--- a/SYCL/KernelFusion/internalize_vfunc.cpp
+++ b/SYCL/KernelFusion/internalize_vfunc.cpp
@@ -4,14 +4,18 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test cancel fusion
+// Test complete fusion with private internalization specified on the
+// accessors for a device kernel with sycl::vec::load and sycl::vec::store.
+
+#define VEC 4
 
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
 
 int main() {
-  constexpr size_t dataSize = 512;
+  constexpr size_t numVec = 512;
+  constexpr size_t dataSize = numVec * VEC;
   int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
 
   for (size_t i = 0; i < dataSize; ++i) {
@@ -39,20 +43,36 @@ int main() {
     q.submit([&](handler &cgh) {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
-      auto accTmp = bTmp.get_access(cgh);
-      cgh.parallel_for<class KernelOne>(
-          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<class KernelOne>(numVec, [=](id<1> i) {
+        size_t offset = i;
+        vec<int, VEC> in1;
+        in1.load(offset, accIn1.get_pointer());
+        vec<int, VEC> in2;
+        in2.load(offset, accIn2.get_pointer());
+        auto tmp = in1 + in2;
+        tmp.store(offset, accTmp.get_pointer());
+      });
     });
 
     q.submit([&](handler &cgh) {
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
       auto accIn3 = bIn3.get_access(cgh);
       auto accOut = bOut.get_access(cgh);
-      cgh.parallel_for<class KernelTwo>(
-          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+      cgh.parallel_for<class KernelTwo>(numVec, [=](id<1> i) {
+        size_t offset = i;
+        vec<int, VEC> tmp;
+        tmp.load(offset, accTmp.get_pointer());
+        vec<int, VEC> in3;
+        in3.load(offset, accIn3.get_pointer());
+        auto out = tmp * in3;
+        out.store(offset, accOut.get_pointer());
+      });
     });
 
-    fw.cancel_fusion();
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
@@ -61,6 +81,7 @@ int main() {
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {
     assert(out[i] == (20 * i * i) && "Computation error");
+    assert(tmp[i] == -1 && "Not internalized");
   }
 
   return 0;

--- a/SYCL/KernelFusion/local_internalization.cpp
+++ b/SYCL/KernelFusion/local_internalization.cpp
@@ -4,7 +4,8 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test cancel fusion
+// Test complete fusion with local internalization specified on the
+// accessors.
 
 #include <sycl/sycl.hpp>
 
@@ -39,20 +40,24 @@ int main() {
     q.submit([&](handler &cgh) {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_local{});
       cgh.parallel_for<class KernelOne>(
-          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+          nd_range<1>{{dataSize}, {16}},
+          [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
     });
 
     q.submit([&](handler &cgh) {
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_local{});
       auto accIn3 = bIn3.get_access(cgh);
       auto accOut = bOut.get_access(cgh);
       cgh.parallel_for<class KernelTwo>(
-          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+          nd_range<1>{{dataSize}, {16}},
+          [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");

--- a/SYCL/KernelFusion/pointer_arg_function.cpp
+++ b/SYCL/KernelFusion/pointer_arg_function.cpp
@@ -1,14 +1,23 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
+// This test currently fails because InferAddressSpace is not able to remove all
+// address-space casts, causing internalization to fail.
+// XFAIL: *
 
-// Test cancel fusion
+// Test complete fusion with private internalization specified on the
+// accessors, calling a function with a raw pointer taken from an accessor in
+// one of the kernels.
 
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
+
+void __attribute__((noinline))
+addFunc(int *in1, int *in2, int *out, size_t linearID) {
+  out[linearID] = in1[linearID] + in2[linearID];
+}
 
 int main() {
   constexpr size_t dataSize = 512;
@@ -39,20 +48,24 @@ int main() {
     q.submit([&](handler &cgh) {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
-      auto accTmp = bTmp.get_access(cgh);
-      cgh.parallel_for<class KernelOne>(
-          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<class KernelOne>(dataSize, [=](item<1> i) {
+        addFunc(accIn1.get_pointer(), accIn2.get_pointer(),
+                accTmp.get_pointer(), i.get_linear_id());
+      });
     });
 
     q.submit([&](handler &cgh) {
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
       auto accIn3 = bIn3.get_access(cgh);
       auto accOut = bOut.get_access(cgh);
       cgh.parallel_for<class KernelTwo>(
           dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
@@ -61,6 +74,7 @@ int main() {
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {
     assert(out[i] == (20 * i * i) && "Computation error");
+    assert(tmp[i] == -1 && "Not internalized");
   }
 
   return 0;

--- a/SYCL/KernelFusion/private_internalization.cpp
+++ b/SYCL/KernelFusion/private_internalization.cpp
@@ -4,7 +4,8 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test cancel fusion
+// Test complete fusion with private internalization specified on the
+// accessors.
 
 #include <sycl/sycl.hpp>
 
@@ -39,20 +40,22 @@ int main() {
     q.submit([&](handler &cgh) {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
       cgh.parallel_for<class KernelOne>(
           dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
     });
 
     q.submit([&](handler &cgh) {
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
       auto accIn3 = bIn3.get_access(cgh);
       auto accOut = bOut.get_access(cgh);
       cgh.parallel_for<class KernelTwo>(
           dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
@@ -61,6 +64,7 @@ int main() {
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {
     assert(out[i] == (20 * i * i) && "Computation error");
+    assert(tmp[i] == -1 && "Not internalized");
   }
 
   return 0;

--- a/SYCL/KernelFusion/ranged_offset_accessor.cpp
+++ b/SYCL/KernelFusion/ranged_offset_accessor.cpp
@@ -1,0 +1,80 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// UNSUPPORTED: cuda || hip
+// REQUIRES: fusion
+
+// Test complete fusion with private internalization on accessors with different
+// offset and range.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr size_t dataSize = 512;
+  int in1[dataSize * 5], in2[dataSize * 5], in3[dataSize * 5],
+      tmp[dataSize * 5], out[dataSize * 5];
+
+  size_t offsetIn1 = 0;
+  size_t offsetIn2 = 512;
+  size_t offsetIn3 = 1024;
+  size_t offsetTmp = 1536;
+  size_t offsetOut = 2048;
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[offsetIn1 + i] = i * 2;
+    in2[offsetIn2 + i] = i * 3;
+    in3[offsetIn3 + i] = i * 4;
+    tmp[offsetTmp + i] = -1;
+    out[offsetOut + i] = -1;
+  }
+
+  queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  {
+    buffer<int> bIn1{in1, range{dataSize * 5}};
+    buffer<int> bIn2{in2, range{dataSize * 5}};
+    buffer<int> bIn3{in3, range{dataSize * 5}};
+    buffer<int> bTmp{tmp, range{dataSize * 5}};
+    buffer<int> bOut{out, range{dataSize * 5}};
+
+    ext::codeplay::experimental::fusion_wrapper fw{q};
+    fw.start_fusion();
+
+    assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access(cgh, range{516}, id{offsetIn1});
+      auto accIn2 = bIn2.get_access(cgh, range{513}, id{offsetIn2});
+      auto accTmp = bTmp.get_access(
+          cgh, range{514}, id{offsetTmp},
+          sycl::ext::codeplay::experimental::property::promote_private{});
+      cgh.parallel_for<class KernelOne>(
+          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp = bTmp.get_access(
+          cgh, range{514}, id{offsetTmp},
+          sycl::ext::codeplay::experimental::property::promote_private{});
+      auto accIn3 = bIn3.get_access(cgh, range{515}, id{offsetIn3});
+      auto accOut = bOut.get_access(cgh, range{512}, id{offsetOut});
+      cgh.parallel_for<class KernelTwo>(
+          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+    });
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+    assert(!fw.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+  }
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[offsetOut + i] == (20 * i * i) && "Computation error");
+    assert(tmp[offsetTmp + i] == -1 && "Not internalized");
+  }
+
+  return 0;
+}

--- a/SYCL/KernelFusion/sync_acc_mem_op.cpp
+++ b/SYCL/KernelFusion/sync_acc_mem_op.cpp
@@ -1,9 +1,12 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
 // UNSUPPORTED: cuda || hip
 
-// Test cancel fusion
+// Test fusion cancellation on an explicit memory operation on an accessor
+// happening before complete_fusion.
 
 #include <sycl/sycl.hpp>
 
@@ -12,6 +15,7 @@ using namespace sycl;
 int main() {
   constexpr size_t dataSize = 512;
   int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
+  int dst[dataSize];
 
   for (size_t i = 0; i < dataSize; ++i) {
     in1[i] = i * 2;
@@ -19,6 +23,7 @@ int main() {
     in3[i] = i * 4;
     tmp[i] = -1;
     out[i] = -1;
+    dst[i] = -1;
   }
 
   queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
@@ -36,8 +41,8 @@ int main() {
     assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
 
     q.submit([&](handler &cgh) {
-      auto accIn1 = bIn1.get_access(cgh);
-      auto accIn2 = bIn2.get_access(cgh);
+      auto accIn1 = bIn1.get_access<access::mode::read>(cgh);
+      auto accIn2 = bIn2.get_access<access::mode::read>(cgh);
       auto accTmp = bTmp.get_access(cgh);
       cgh.parallel_for<class KernelOne>(
           dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
@@ -51,16 +56,29 @@ int main() {
           dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    // This explicit copy operation has an overlapping requirement with one of
+    // the kernels and therefore requires synchronization. This should lead to
+    // cancellation of the fusion.
+    auto copyEvt = q.submit([&](handler &cgh) {
+      auto accTmp = bTmp.get_access(cgh);
+      cgh.copy(accTmp, dst);
+    });
+
+    copyEvt.wait();
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
   }
 
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {
     assert(out[i] == (20 * i * i) && "Computation error");
+    assert(dst[i] == (5 * i) && "Computation error");
   }
 
   return 0;
 }
+
+// CHECK: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/sync_buffer_destruction.cpp
+++ b/SYCL/KernelFusion/sync_buffer_destruction.cpp
@@ -1,0 +1,76 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
+// UNSUPPORTED: cuda || hip
+
+// Test fusion cancellation on buffer destruction happening before
+// complete_fusion.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr size_t dataSize = 512;
+  int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+
+  queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  {
+    buffer<int> bIn1{in1, range{dataSize}};
+    buffer<int> bIn2{in2, range{dataSize}};
+    buffer<int> bTmp{tmp, range{dataSize}};
+    buffer<int> bOut{out, range{dataSize}};
+
+    ext::codeplay::experimental::fusion_wrapper fw{q};
+    {
+      buffer<int> bIn3{in3, range{dataSize}};
+
+      fw.start_fusion();
+
+      assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+      q.submit([&](handler &cgh) {
+        auto accIn1 = bIn1.get_access<access::mode::read>(cgh);
+        auto accIn2 = bIn2.get_access<access::mode::read>(cgh);
+        auto accTmp = bTmp.get_access(cgh);
+        cgh.parallel_for<class KernelOne>(
+            dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+      });
+
+      q.submit([&](handler &cgh) {
+        auto accTmp = bTmp.get_access(cgh);
+        auto accIn3 = bIn3.get_access(cgh);
+        auto accOut = bOut.get_access(cgh);
+        cgh.parallel_for<class KernelTwo>(
+            dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+      });
+      // Buffer bIn3, which is accessed by one of the kernels in the fusion list
+      // goes out scope, causing a blocking wait for one of the kernels in the
+      // fusion list. This should lead to cancellation of the fusion.
+    }
+    assert(!fw.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+  }
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[i] == (20 * i * i) && "Computation error");
+  }
+
+  return 0;
+}
+
+// CHECK: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/sync_event_wait.cpp
+++ b/SYCL/KernelFusion/sync_event_wait.cpp
@@ -1,9 +1,12 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
 // UNSUPPORTED: cuda || hip
 
-// Test cancel fusion
+// Test fusion cancellation on event::wait() happening before
+// complete_fusion.
 
 #include <sycl/sycl.hpp>
 
@@ -35,9 +38,9 @@ int main() {
 
     assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
 
-    q.submit([&](handler &cgh) {
-      auto accIn1 = bIn1.get_access(cgh);
-      auto accIn2 = bIn2.get_access(cgh);
+    auto kernel1Ev = q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access<access::mode::read>(cgh);
+      auto accIn2 = bIn2.get_access<access::mode::read>(cgh);
       auto accTmp = bTmp.get_access(cgh);
       cgh.parallel_for<class KernelOne>(
           dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
@@ -51,10 +54,14 @@ int main() {
           dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    // This event::wait() causes a blocking wait for one of the kernels in the
+    // fusion list. This should lead to cancellation of the fusion.
+    kernel1Ev.wait();
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
   }
 
   // Check the results
@@ -64,3 +71,5 @@ int main() {
 
   return 0;
 }
+
+// CHECK: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/sync_host_task.cpp
+++ b/SYCL/KernelFusion/sync_host_task.cpp
@@ -1,9 +1,12 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
 // UNSUPPORTED: cuda || hip
 
-// Test cancel fusion
+// Test fusion cancellation on host task submission happening before
+// complete_fusion.
 
 #include <sycl/sycl.hpp>
 
@@ -36,8 +39,8 @@ int main() {
     assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
 
     q.submit([&](handler &cgh) {
-      auto accIn1 = bIn1.get_access(cgh);
-      auto accIn2 = bIn2.get_access(cgh);
+      auto accIn1 = bIn1.get_access<access::mode::read>(cgh);
+      auto accIn2 = bIn2.get_access<access::mode::read>(cgh);
       auto accTmp = bTmp.get_access(cgh);
       cgh.parallel_for<class KernelOne>(
           dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
@@ -51,16 +54,31 @@ int main() {
           dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    // This host task requests access to bOut, which is accessed by one of
+    // the kernels in the fusion list, creating a requirement for one of the
+    // kernels in the fusion list. This should lead to cancellation of the
+    // fusion.
+    q.submit([&](handler &cgh) {
+      auto accOut = bOut.get_access(cgh);
+      cgh.host_task([=]() { accOut[256] = 42; });
+    });
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
   }
 
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {
-    assert(out[i] == (20 * i * i) && "Computation error");
+    if (i == 256) {
+      assert(out[i] == 42 && "Computation error");
+    } else {
+      assert(out[i] == (20 * i * i) && "Computation error");
+    }
   }
 
   return 0;
 }
+
+// CHECK: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/sync_queue_destruction.cpp
+++ b/SYCL/KernelFusion/sync_queue_destruction.cpp
@@ -1,0 +1,71 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
+// UNSUPPORTED: cuda || hip
+
+// Test fusion cancellation on queue destruction happening before
+// complete_fusion.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr size_t dataSize = 512;
+  int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+
+  {
+    buffer<int> bIn1{in1, range{dataSize}};
+    buffer<int> bIn2{in2, range{dataSize}};
+    buffer<int> bTmp{tmp, range{dataSize}};
+    buffer<int> bOut{out, range{dataSize}};
+    buffer<int> bIn3{in3, range{dataSize}};
+
+    {
+      queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+      ext::codeplay::experimental::fusion_wrapper fw{q};
+      fw.start_fusion();
+
+      assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+      q.submit([&](handler &cgh) {
+        auto accIn1 = bIn1.get_access<access::mode::read>(cgh);
+        auto accIn2 = bIn2.get_access<access::mode::read>(cgh);
+        auto accTmp = bTmp.get_access(cgh);
+        cgh.parallel_for<class KernelOne>(
+            dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+      });
+
+      q.submit([&](handler &cgh) {
+        auto accTmp = bTmp.get_access(cgh);
+        auto accIn3 = bIn3.get_access(cgh);
+        auto accOut = bOut.get_access(cgh);
+        cgh.parallel_for<class KernelTwo>(
+            dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+      });
+      // Queue q, which is still in fusion mode and to which all kernels have
+      // been submitted, goes out-of-scope here. This should lead to
+      // cancellation of the fusion.
+    }
+  }
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[i] == (20 * i * i) && "Computation error");
+  }
+
+  return 0;
+}
+
+// CHECK: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/sync_queue_wait.cpp
+++ b/SYCL/KernelFusion/sync_queue_wait.cpp
@@ -1,9 +1,12 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
 // UNSUPPORTED: cuda || hip
 
-// Test cancel fusion
+// Test fusion cancellation on queue::wait() happening before
+// complete_fusion.
 
 #include <sycl/sycl.hpp>
 
@@ -36,8 +39,8 @@ int main() {
     assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
 
     q.submit([&](handler &cgh) {
-      auto accIn1 = bIn1.get_access(cgh);
-      auto accIn2 = bIn2.get_access(cgh);
+      auto accIn1 = bIn1.get_access<access::mode::read>(cgh);
+      auto accIn2 = bIn2.get_access<access::mode::read>(cgh);
       auto accTmp = bTmp.get_access(cgh);
       cgh.parallel_for<class KernelOne>(
           dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
@@ -51,10 +54,14 @@ int main() {
           dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    // This queue.wait() causes a blocking wait for all of the kernels in the
+    // fusion list. This should lead to cancellation of the fusion.
+    q.wait();
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
+
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
   }
 
   // Check the results
@@ -64,3 +71,5 @@ int main() {
 
   return 0;
 }
+
+// CHECK: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/sync_two_queues_event_dep.cpp
+++ b/SYCL/KernelFusion/sync_two_queues_event_dep.cpp
@@ -1,0 +1,91 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
+// UNSUPPORTED: cuda || hip
+
+// For this test, complete_fusion must be supported, which is currently not the
+// case on Windows.
+// REQUIRES: linux
+
+// Test fusion cancellation on event dependency between two active fusions.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr size_t dataSize = 512;
+
+  queue q1{ext::codeplay::experimental::property::queue::enable_fusion{}};
+  queue q2{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  int *in1 = sycl::malloc_shared<int>(dataSize, q1);
+  int *in2 = sycl::malloc_shared<int>(dataSize, q1);
+  int *in3 = sycl::malloc_shared<int>(dataSize, q1);
+  int *tmp = sycl::malloc_shared<int>(dataSize, q1);
+  int *out = sycl::malloc_shared<int>(dataSize, q1);
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+
+  ext::codeplay::experimental::fusion_wrapper fw1{q1};
+  fw1.start_fusion();
+
+  assert(fw1.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+  auto kernel1 = q1.submit([&](handler &cgh) {
+    cgh.parallel_for<class KernelOne>(
+        dataSize, [=](id<1> i) { tmp[i] = in1[i] + in2[i]; });
+  });
+
+  ext::codeplay::experimental::fusion_wrapper fw2{q2};
+  fw2.start_fusion();
+
+  auto kernel3 = q2.submit([&](handler &cgh) {
+    cgh.depends_on(kernel1);
+    cgh.parallel_for<class KernelThree>(dataSize,
+                                        [=](id<1> i) { tmp[i] *= 2; });
+  });
+
+  // kernel3 specifies an event dependency on kernel1. To avoid circular
+  // dependencies between two fusions, the fusion for q1 needs to cancelled.
+  assert(!fw1.is_in_fusion_mode() &&
+         "Queue should not be in fusion mode anymore");
+
+  assert(fw2.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+  auto kernel2 = q1.submit([&](handler &cgh) {
+    cgh.depends_on(kernel3);
+    cgh.parallel_for<class KernelTwo>(
+        dataSize, [=](id<1> i) { out[i] = tmp[i] * in3[i]; });
+  });
+
+  // kernel2 specifies an event dependency on kernel3, which leads to
+  // cancellation of the fusion for q2.
+  assert(!fw2.is_in_fusion_mode() &&
+         "Queue should not be in fusion mode anymore");
+
+  fw1.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+  fw2.cancel_fusion();
+
+  q1.wait();
+  q2.wait();
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[i] == (40 * i * i) && "Computation error");
+  }
+
+  return 0;
+}
+
+// CHECK: WARNING: Aborting fusion because of event dependency from a different fusion
+// CHECK-NEXT: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/sync_two_queues_event_dep.cpp
+++ b/SYCL/KernelFusion/sync_two_queues_event_dep.cpp
@@ -4,10 +4,8 @@
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
 // RUN: %GPU_CHECK_PLACEHOLDER
 // UNSUPPORTED: cuda || hip
-
-// For this test, complete_fusion must be supported, which is currently not the
-// case on Windows.
-// REQUIRES: linux
+// For this test, complete_fusion must be supported.
+// REQUIRES: fusion
 
 // Test fusion cancellation on event dependency between two active fusions.
 

--- a/SYCL/KernelFusion/sync_two_queues_requirement.cpp
+++ b/SYCL/KernelFusion/sync_two_queues_requirement.cpp
@@ -1,0 +1,96 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
+// UNSUPPORTED: cuda || hip
+
+// For this test, complete_fusion must be supported, which is currently not the
+// case on Windows.
+// REQUIRES: linux
+
+// Test fusion cancellation for requirement between two active fusions.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr size_t dataSize = 512;
+  int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+
+  queue q1{ext::codeplay::experimental::property::queue::enable_fusion{}};
+  queue q2{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  {
+    buffer<int> bIn1{in1, range{dataSize}};
+    buffer<int> bIn2{in2, range{dataSize}};
+    buffer<int> bTmp{tmp, range{dataSize}};
+    buffer<int> bOut{out, range{dataSize}};
+    buffer<int> bIn3{in3, range{dataSize}};
+
+    ext::codeplay::experimental::fusion_wrapper fw1{q1};
+    fw1.start_fusion();
+
+    assert(fw1.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q1.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access<access::mode::read>(cgh);
+      auto accIn2 = bIn2.get_access<access::mode::read>(cgh);
+      auto accTmp = bTmp.get_access(cgh);
+      cgh.parallel_for<class KernelOne>(
+          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+    });
+
+    ext::codeplay::experimental::fusion_wrapper fw2{q2};
+    fw2.start_fusion();
+
+    q2.submit([&](handler &cgh) {
+      auto accTmp = bTmp.get_access(cgh);
+      cgh.parallel_for<class KernelThree>(dataSize,
+                                          [=](id<1> i) { accTmp[i] *= 2; });
+    });
+
+    // KernelThree specifies a requirement on KernelOne. To avoid circular
+    // dependencies between two fusions, the fusion for q1 needs to cancelled.
+    assert(!fw1.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+
+    assert(fw2.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+    q1.submit([&](handler &cgh) {
+      auto accTmp = bTmp.get_access(cgh);
+      auto accIn3 = bIn3.get_access(cgh);
+      auto accOut = bOut.get_access(cgh);
+      cgh.parallel_for<class KernelTwo>(
+          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+    });
+
+    // KernelTwo specifies a requirement on KernelThree, which leads to
+    // cancellation of the fusion for q2.
+    assert(!fw2.is_in_fusion_mode() &&
+           "Queue should not be in fusion mode anymore");
+
+    fw1.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+    fw2.cancel_fusion();
+  }
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[i] == (40 * i * i) && "Computation error");
+  }
+
+  return 0;
+}
+
+// CHECK: WARNING: Aborting fusion because of requirement from a different fusion
+// CHECK-NEXT: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/sync_two_queues_requirement.cpp
+++ b/SYCL/KernelFusion/sync_two_queues_requirement.cpp
@@ -4,10 +4,8 @@
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
 // RUN: %GPU_CHECK_PLACEHOLDER
 // UNSUPPORTED: cuda || hip
-
-// For this test, complete_fusion must be supported, which is currently not the
-// case on Windows.
-// REQUIRES: linux
+// For this test, complete_fusion must be supported.
+// REQUIRES: fusion
 
 // Test fusion cancellation for requirement between two active fusions.
 

--- a/SYCL/KernelFusion/sync_usm_mem_op.cpp
+++ b/SYCL/KernelFusion/sync_usm_mem_op.cpp
@@ -1,0 +1,79 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_RT_WARNING_LEVEL=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1\
+// RUN: %GPU_CHECK_PLACEHOLDER
+// UNSUPPORTED: cuda || hip
+
+// Test fusion cancellation on an explicit memory operation on an USM pointer
+// happening before complete_fusion.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr size_t dataSize = 512;
+
+  queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  int *in1 = sycl::malloc_shared<int>(dataSize, q);
+  int *in2 = sycl::malloc_shared<int>(dataSize, q);
+  int *in3 = sycl::malloc_shared<int>(dataSize, q);
+  int *tmp = sycl::malloc_shared<int>(dataSize, q);
+  int *out = sycl::malloc_shared<int>(dataSize, q);
+  int dst[dataSize];
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+    dst[i] = -1;
+  }
+
+  ext::codeplay::experimental::fusion_wrapper fw{q};
+  fw.start_fusion();
+
+  assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+  auto kernel1 = q.submit([&](handler &cgh) {
+    cgh.parallel_for<class KernelOne>(
+        dataSize, [=](id<1> i) { tmp[i] = in1[i] + in2[i]; });
+  });
+
+  auto kernel2 = q.submit([&](handler &cgh) {
+    cgh.depends_on(kernel1);
+    cgh.parallel_for<class KernelTwo>(
+        dataSize, [=](id<1> i) { out[i] = tmp[i] * in3[i]; });
+  });
+
+  // This explicit copy operation has an explicit dependency on one of the
+  // kernels and therefore requires synchronization. This should lead to
+  // cancellation of the fusion.
+  auto copyEvt = q.copy(tmp, dst, dataSize, kernel1);
+
+  copyEvt.wait();
+
+  assert(!fw.is_in_fusion_mode() &&
+         "Queue should not be in fusion mode anymore");
+
+  fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[i] == (20 * i * i) && "Computation error");
+    assert(dst[i] == (5 * i) && "Computation error");
+  }
+
+  sycl::free(in1, q);
+  sycl::free(in2, q);
+  sycl::free(in3, q);
+  sycl::free(tmp, q);
+  sycl::free(out, q);
+
+  return 0;
+}
+
+// CHECK: WARNING: Aborting fusion because synchronization with one of the kernels in the fusion list was requested

--- a/SYCL/KernelFusion/three_dimensional.cpp
+++ b/SYCL/KernelFusion/three_dimensional.cpp
@@ -4,14 +4,18 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test cancel fusion
+// Test complete fusion with private internalization specified on the
+// accessors for three-dimensional range.
 
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
 
 int main() {
-  constexpr size_t dataSize = 512;
+  constexpr size_t sizeX = 16;
+  constexpr size_t sizeY = 8;
+  constexpr size_t sizeZ = 4;
+  constexpr size_t dataSize = sizeX * sizeY * sizeZ;
   int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
 
   for (size_t i = 0; i < dataSize; ++i) {
@@ -25,11 +29,12 @@ int main() {
   queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
 
   {
-    buffer<int> bIn1{in1, range{dataSize}};
-    buffer<int> bIn2{in2, range{dataSize}};
-    buffer<int> bIn3{in3, range{dataSize}};
-    buffer<int> bTmp{tmp, range{dataSize}};
-    buffer<int> bOut{out, range{dataSize}};
+    range<3> xyRange{sizeZ, sizeY, sizeX};
+    buffer<int, 3> bIn1{in1, xyRange};
+    buffer<int, 3> bIn2{in2, xyRange};
+    buffer<int, 3> bIn3{in3, xyRange};
+    buffer<int, 3> bTmp{tmp, xyRange};
+    buffer<int, 3> bOut{out, xyRange};
 
     ext::codeplay::experimental::fusion_wrapper fw{q};
     fw.start_fusion();
@@ -39,20 +44,22 @@ int main() {
     q.submit([&](handler &cgh) {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
       cgh.parallel_for<class KernelOne>(
-          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+          xyRange, [=](id<3> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
     });
 
     q.submit([&](handler &cgh) {
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
       auto accIn3 = bIn3.get_access(cgh);
       auto accOut = bOut.get_access(cgh);
       cgh.parallel_for<class KernelTwo>(
-          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+          xyRange, [=](id<3> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
@@ -61,6 +68,7 @@ int main() {
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {
     assert(out[i] == (20 * i * i) && "Computation error");
+    assert(tmp[i] == -1 && "Not internalized");
   }
 
   return 0;

--- a/SYCL/KernelFusion/two_dimensional.cpp
+++ b/SYCL/KernelFusion/two_dimensional.cpp
@@ -4,14 +4,17 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test cancel fusion
+// Test complete fusion with private internalization specified on the
+// accessors for two-dimensional range.
 
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
 
 int main() {
-  constexpr size_t dataSize = 512;
+  constexpr size_t sizeX = 16;
+  constexpr size_t sizeY = 32;
+  constexpr size_t dataSize = sizeX * sizeY;
   int in1[dataSize], in2[dataSize], in3[dataSize], tmp[dataSize], out[dataSize];
 
   for (size_t i = 0; i < dataSize; ++i) {
@@ -25,11 +28,12 @@ int main() {
   queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
 
   {
-    buffer<int> bIn1{in1, range{dataSize}};
-    buffer<int> bIn2{in2, range{dataSize}};
-    buffer<int> bIn3{in3, range{dataSize}};
-    buffer<int> bTmp{tmp, range{dataSize}};
-    buffer<int> bOut{out, range{dataSize}};
+    range<2> xyRange{sizeY, sizeX};
+    buffer<int, 2> bIn1{in1, xyRange};
+    buffer<int, 2> bIn2{in2, xyRange};
+    buffer<int, 2> bIn3{in3, xyRange};
+    buffer<int, 2> bTmp{tmp, xyRange};
+    buffer<int, 2> bOut{out, xyRange};
 
     ext::codeplay::experimental::fusion_wrapper fw{q};
     fw.start_fusion();
@@ -39,20 +43,22 @@ int main() {
     q.submit([&](handler &cgh) {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
       cgh.parallel_for<class KernelOne>(
-          dataSize, [=](id<1> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
+          xyRange, [=](id<2> i) { accTmp[i] = accIn1[i] + accIn2[i]; });
     });
 
     q.submit([&](handler &cgh) {
-      auto accTmp = bTmp.get_access(cgh);
+      auto accTmp = bTmp.get_access(
+          cgh, sycl::ext::codeplay::experimental::property::promote_private{});
       auto accIn3 = bIn3.get_access(cgh);
       auto accOut = bOut.get_access(cgh);
       cgh.parallel_for<class KernelTwo>(
-          dataSize, [=](id<1> i) { accOut[i] = accTmp[i] * accIn3[i]; });
+          xyRange, [=](id<2> i) { accOut[i] = accTmp[i] * accIn3[i]; });
     });
 
-    fw.cancel_fusion();
+    fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
 
     assert(!fw.is_in_fusion_mode() &&
            "Queue should not be in fusion mode anymore");
@@ -61,6 +67,7 @@ int main() {
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {
     assert(out[i] == (20 * i * i) && "Computation error");
+    assert(tmp[i] == -1 && "Not internalized");
   }
 
   return 0;

--- a/SYCL/KernelFusion/usm_no_dependencies.cpp
+++ b/SYCL/KernelFusion/usm_no_dependencies.cpp
@@ -4,9 +4,7 @@
 // UNSUPPORTED: cuda || hip
 // REQUIRES: fusion
 
-// Test validity of events after cancel_fusion.
-
-#include "fusion_event_test_common.h"
+// Test complete fusion using USM pointers.
 
 #include <sycl/sycl.hpp>
 
@@ -36,33 +34,22 @@ int main() {
 
   assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
 
-  auto kernel1 = q.submit([&](handler &cgh) {
+  q.submit([&](handler &cgh) {
     cgh.parallel_for<class KernelOne>(
         dataSize, [=](id<1> i) { tmp[i] = in1[i] + in2[i]; });
   });
 
-  auto kernel2 = q.submit([&](handler &cgh) {
-    cgh.depends_on(kernel1);
+  q.submit([&](handler &cgh) {
     cgh.parallel_for<class KernelTwo>(
         dataSize, [=](id<1> i) { out[i] = tmp[i] * in3[i]; });
   });
 
-  fw.cancel_fusion();
+  fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
 
   assert(!fw.is_in_fusion_mode() &&
          "Queue should not be in fusion mode anymore");
 
-  kernel1.wait();
-  assert(isEventComplete(kernel1) && "Event should be complete");
-  // The event returned by submit while in fusion mode depends on both
-  // individual kernels to be executed.
-  assert(kernel1.get_wait_list().size() == 2);
-
-  kernel2.wait();
-  assert(isEventComplete(kernel2) && "Event should be complete");
-  // The event returned by submit while in fusion mode depends on both
-  // individual kernels to be executed.
-  assert(kernel2.get_wait_list().size() == 2);
+  q.wait();
 
   // Check the results
   for (size_t i = 0; i < dataSize; ++i) {

--- a/SYCL/KernelFusion/wrapped_usm.cpp
+++ b/SYCL/KernelFusion/wrapped_usm.cpp
@@ -1,0 +1,76 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// UNSUPPORTED: cuda || hip
+// REQUIRES: fusion
+
+// Test complete fusion using an wrapped USM pointer as kernel functor argument.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+template <typename T> struct wrapper {
+  T *data;
+
+  wrapper(size_t dataSize, queue &q)
+      : data{sycl::malloc_shared<int>(dataSize, q)} {}
+
+  T &operator[](size_t i) { return data[i]; }
+  const T &operator[](size_t i) const { return data[i]; }
+};
+
+int main() {
+  constexpr size_t dataSize = 512;
+
+  queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
+
+  wrapper<int> in1{dataSize, q};
+  wrapper<int> in2{dataSize, q};
+  wrapper<int> in3{dataSize, q};
+  wrapper<int> tmp{dataSize, q};
+  wrapper<int> out{dataSize, q};
+
+  for (size_t i = 0; i < dataSize; ++i) {
+    in1[i] = i * 2;
+    in2[i] = i * 3;
+    in3[i] = i * 4;
+    tmp[i] = -1;
+    out[i] = -1;
+  }
+
+  ext::codeplay::experimental::fusion_wrapper fw{q};
+  fw.start_fusion();
+
+  assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+
+  q.submit([&](handler &cgh) {
+    cgh.parallel_for<class KernelOne>(
+        dataSize, [=](id<1> i) { tmp.data[i] = in1.data[i] + in2.data[i]; });
+  });
+
+  q.submit([&](handler &cgh) {
+    cgh.parallel_for<class KernelTwo>(
+        dataSize, [=](id<1> i) { out.data[i] = tmp.data[i] * in3.data[i]; });
+  });
+
+  fw.complete_fusion({ext::codeplay::experimental::property::no_barriers{}});
+
+  assert(!fw.is_in_fusion_mode() &&
+         "Queue should not be in fusion mode anymore");
+
+  q.wait();
+
+  // Check the results
+  for (size_t i = 0; i < dataSize; ++i) {
+    assert(out[i] == (20 * i * i) && "Computation error");
+  }
+
+  sycl::free(in1.data, q);
+  sycl::free(in2.data, q);
+  sycl::free(in3.data, q);
+  sycl::free(tmp.data, q);
+  sycl::free(out.data, q);
+
+  return 0;
+}

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -427,6 +427,23 @@ for aot_tool in aot_tools:
     else:
         lit_config.warning("Couldn't find pre-installed AOT device compiler " + aot_tool)
 
+# Check if kernel fusion is available by compiling a small program that will
+# be ill-formed (compilation stops with non-zero exit code) if the feature
+# test macro for kernel fusion is not defined.
+check_fusion_file = 'check_fusion.cpp'
+with open(check_fusion_file, 'w') as ff:
+    ff.write('#include <sycl/sycl.hpp>\n')
+    ff.write('#ifndef SYCL_EXT_CODEPLAY_KERNEL_FUSION\n')
+    ff.write('#error \"Feature test for fusion failed\"\n')
+    ff.write('#endif // SYCL_EXT_CODEPLAY_KERNEL_FUSION\n')
+    ff.write('int main() { return 0; }\n')
+
+status = subprocess.getstatusoutput(config.dpcpp_compiler + ' -fsycl  ' +
+                                    check_fusion_file)
+if status[0] == 0:
+    lit_config.note('Kernel fusion extension enabled')
+    config.available_features.add('fusion')
+
 # Set timeout for a single test
 try:
     import psutil


### PR DESCRIPTION
Test different scenarios for kernel fusion, including creation of the fused kernel by the JIT compiler and performance optimizations such as dataflow internalization.

Automatically detect availability of the kernel fusion extension in the DPC++ build in `lit.cfg.py` and make it available for `REQUIRES` clauses.